### PR TITLE
Fix for MariaDB migrations

### DIFF
--- a/PHP/Laravel_MariaDB_Migration_Fix/AppServiceProvider.php
+++ b/PHP/Laravel_MariaDB_Migration_Fix/AppServiceProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+Fix for MariaDB or older versions of MySQL when running migrations.
+Just place it in your AppServiceProvider.php file.
+*/
+
+use Illuminate\Support\Facades\Schema;
+
+public function boot()
+{
+    Schema::defaultStringLength(191);
+}


### PR DESCRIPTION
As far as I know this has not been fixed yet in Laravel, so to avoid the error just add this to AppServiceProvider.php file.